### PR TITLE
feat: Add CI job to run `make test-sample-docs`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   # We can switch to running on push if we make this repo public or are fine with
   # paying for CI minutes.
   push:
-    branches: [ main ]
+    branches: [ main , core-182/ci-add-test-sample-docs]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   # We can switch to running on push if we make this repo public or are fine with
   # paying for CI minutes.
   push:
-    branches: [ main , core-182/ci-add-test-sample-docs]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   # We can switch to running on push if we make this repo public or are fine with
   # paying for CI minutes.
   push:
-    branches: [ main ]
+    branches: [ main , core-182/ci-add-test-sample-docs]
   pull_request:
     branches: [ main ]
 
@@ -90,11 +90,16 @@ jobs:
       with:
         path: /home/runner/nltk_data
         key: ci-nltk-${{ hashFiles('requirements/*.txt') }}
-    - name: Test
+    - name: Run core tests 
       run: |
         source .venv/bin/activate
         make test
         make check-coverage
+    - name: Run sample SEC documents tests
+      run: |
+        source .venv/bin/activate
+        make dl-test-artifacts
+        make test-sample-docs
 
   changelog:
     runs-on: ubuntu-latest

--- a/test_sec_filings/test_sec_document.py
+++ b/test_sec_filings/test_sec_document.py
@@ -134,7 +134,7 @@ def elements():
 def test_get_dividend_narrative(section_name, sample_document):
     sec_document = SECDocument.from_string(sample_document)
     sections = sec_document.get_section_narrative(section_name)
-    assert sections == [
+    assert not sections == [
         NarrativeText(text="Sometimes we disperse dividends, and everyone gets money."),
         NarrativeText(text="Sometimes we don't disperse dividends, and nobody gets money."),
     ]

--- a/test_sec_filings/test_sec_document.py
+++ b/test_sec_filings/test_sec_document.py
@@ -134,7 +134,7 @@ def elements():
 def test_get_dividend_narrative(section_name, sample_document):
     sec_document = SECDocument.from_string(sample_document)
     sections = sec_document.get_section_narrative(section_name)
-    assert not sections == [
+    assert sections == [
         NarrativeText(text="Sometimes we disperse dividends, and everyone gets money."),
         NarrativeText(text="Sometimes we don't disperse dividends, and nobody gets money."),
     ]


### PR DESCRIPTION
### Summary
Adds CI to run `make test-sample-docs` which takes around 10 mins to finish testing on sample docs.

### Test
CI won't test sample docs if the core tests fail before it.