### PR TITLE
ci: Use same hash everywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         path: |
           .venv
           sample-sec-docs
-        key: ci-venv-sec-docs-${{ hashFiles('requirements/*.txt') }}
+        key: ci-venv-sec-docs-${{ hashFiles('requirements/*.txt', 'sample-sec-docs/sample-sec-docs.sha256') }}
     - name: Lint
       run: |
         source .venv/bin/activate
@@ -74,7 +74,7 @@ jobs:
         path: |
           .venv
           sample-sec-docs
-        key: ci-venv-sec-docs-${{ hashFiles('requirements/*.txt') }}
+        key: ci-venv-sec-docs-${{ hashFiles('requirements/*.txt', 'sample-sec-docs/sample-sec-docs.sha256') }}
     - uses: actions/cache@v3
       id: nltk-cache
       with:
@@ -117,7 +117,7 @@ jobs:
         path: |
           .venv
           sample-sec-docs
-        key: ci-venv-sec-docs-${{ hashFiles('requirements/*.txt') }}
+        key: ci-venv-sec-docs-${{ hashFiles('requirements/*.txt', 'sample-sec-docs/sample-sec-docs.sha256') }}
     - name: API Consistency
       run: |
         source .venv/bin/activate


### PR DESCRIPTION
The CI broke, and I think it's due to using different hash keys for the `ci-venv-sec-docs` caches. This makes the hash keys consistent.