### PR TITLE
Bump pipeline and route version

### DIFF
--- a/prepline_sec_filings/api/section.py
+++ b/prepline_sec_filings/api/section.py
@@ -114,7 +114,7 @@ def pipeline_api(text, m_section=[], m_section_regex=[]):
     }
 
 
-@app.post("/sec-filings/v0.0.1/section")
+@app.post("/sec-filings/v0.0.2/section")
 @limiter.limit(RATE_LIMIT)
 async def pipeline_1(
     request: Request,

--- a/preprocessing-pipeline-family.yaml
+++ b/preprocessing-pipeline-family.yaml
@@ -1,2 +1,2 @@
 name: sec-filings
-version: 0.0.1
+version: 0.0.2

--- a/test_sec_filings/sec_filings/test_section_api.py
+++ b/test_sec_filings/sec_filings/test_section_api.py
@@ -3,7 +3,11 @@ import pytest
 
 from fastapi.testclient import TestClient
 
+from unstructured_api_tools.pipelines.api_conventions import get_pipeline_path
+
 from prepline_sec_filings.api.section import app
+
+SECTION_ROUTE = get_pipeline_path("section")
 
 
 def generate_sample_document(form_type):
@@ -49,7 +53,7 @@ def test_risk_narrative_api(form_type, section, tmpdir):
     app.state.limiter.reset()
     client = TestClient(app)
     response = client.post(
-        "sec-filings/v0.0.1/section",
+        SECTION_ROUTE,
         files={"file": (filename, open(filename, "rb"), "text/plain")},
         data={"section": [section]},
     )
@@ -87,7 +91,7 @@ def test_risk_narrative_api_with_custom_regex(form_type, tmpdir):
     app.state.limiter.reset()
     client = TestClient(app)
     response = client.post(
-        "sec-filings/v0.0.1/section",
+        SECTION_ROUTE,
         files={"file": (filename, open(filename, "rb"), "text/plain")},
         data={"section_regex": ["risk factors"]},
     )
@@ -125,7 +129,7 @@ def test_risk_narrative_api_with_custom_regex_with_special_chars(form_type, tmpd
     app.state.limiter.reset()
     client = TestClient(app)
     response = client.post(
-        "sec-filings/v0.0.1/section",
+        SECTION_ROUTE,
         files={"file": (filename, open(filename, "rb"), "text/plain")},
         data={"section_regex": ["^(?:prospectus )?summary$"]},
     )


### PR DESCRIPTION
With the addition of a new API parameter, let's bump the pipeline version, which implies
bumping the route version after `make generate-api`.