### PR TITLE
chore: exploration-notebooks fetch risks the generic way

### DIFF
--- a/exploration-notebooks/exploration-10k-risks.ipynb
+++ b/exploration-notebooks/exploration-10k-risks.ipynb
@@ -98,7 +98,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "risk_sections = sec_document.get_risk_narrative()"
+    "from prepline_sec_filings.sections import SECSection\n",
+    "risk_sections = sec_document.get_section_narrative(SECSection.RISK_FACTORS)"
    ]
   },
   {
@@ -206,7 +207,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "risk_sections = sec_document.get_risk_narrative()"
+    "risk_sections = sec_document.get_section_narrative(SECSection.RISK_FACTORS)"
    ]
   },
   {
@@ -269,7 +270,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69a6681e",
+   "id": "126792e8",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/exploration-notebooks/exploration-10k-risks.ipynb
+++ b/exploration-notebooks/exploration-10k-risks.ipynb
@@ -270,7 +270,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "126792e8",
+   "id": "69a6681e",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/exploration-notebooks/exploration-10q-amended.ipynb
+++ b/exploration-notebooks/exploration-10q-amended.ipynb
@@ -448,6 +448,18 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/exploration-notebooks/exploration-10q-amended.ipynb
+++ b/exploration-notebooks/exploration-10q-amended.ipynb
@@ -448,18 +448,6 @@
    "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/exploration-notebooks/exploration-s1-risks.ipynb
+++ b/exploration-notebooks/exploration-s1-risks.ipynb
@@ -98,7 +98,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "risk_narrative = sec_document.get_risk_narrative()"
+    "from prepline_sec_filings.sections import SECSection\n",
+    "risk_narrative = sec_document.get_section_narrative(SECSection.RISK_FACTORS)"
    ]
   },
   {
@@ -213,7 +214,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "risk_narrative = sec_document.get_risk_narrative()"
+    "risk_narrative = sec_document.get_section_narrative(SECSection.RISK_FACTORS)"
    ]
   },
   {


### PR DESCRIPTION
In the exploration notebooks exploring risk narratives, update the way the section is fetched to use the newer generic `get_section_narrative` method. This makes the notebooks super easy to try out with sections other than RISK_FACTORS.