### PR TITLE
chore: bump to unstructured-api-tools==0.4.2

### DIFF
--- a/prepline_sec_filings/api/section.py
+++ b/prepline_sec_filings/api/section.py
@@ -192,9 +192,7 @@ async def pipeline_1(
 
     if isinstance(text_files, list) and len(text_files):
         if len(text_files) > 1:
-            if content_type and (
-                content_type != "*/*" and content_type != "multipart/mixed"
-            ):
+            if content_type and content_type not in ["*/*", "multipart/mixed"]:
                 return PlainTextResponse(
                     content=(
                         f"Conflict in media type {content_type}"
@@ -205,28 +203,30 @@ async def pipeline_1(
 
             def response_generator():
                 for file in text_files:
+
                     text = file.file.read().decode("utf-8")
 
                     response = pipeline_api(
                         text,
-                        section,
-                        section_regex,
+                        m_section=section,
+                        m_section_regex=section_regex,
                     )
-
                     if type(response) not in [str, bytes]:
                         response = json.dumps(response)
                     yield response
 
-            return MultipartMixedResponse(response_generator())
-
+            return MultipartMixedResponse(
+                response_generator(),
+            )
         else:
+
             text_file = text_files[0]
             text = text_file.file.read().decode("utf-8")
 
             response = pipeline_api(
                 text,
-                section,
-                section_regex,
+                m_section=section,
+                m_section_regex=section_regex,
             )
 
             return response

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,5 @@
 unstructured==0.2.1
-unstructured_api_tools==0.4.0
+unstructured_api_tools==0.4.2
 
 ratelimit
 requests

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -160,6 +160,8 @@ traitlets==5.4.0
     #   nbformat
 types-requests==2.28.11
     # via unstructured-api-tools
+types-ujson==5.5.0
+    # via unstructured-api-tools
 types-urllib3==1.26.24
     # via types-requests
 typing-extensions==4.3.0
@@ -168,7 +170,7 @@ typing-extensions==4.3.0
     #   starlette
 unstructured==0.2.1
     # via -r requirements/base.in
-unstructured-api-tools==0.4.0
+unstructured-api-tools==0.4.2
     # via -r requirements/base.in
 urllib3==1.26.12
     # via requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile requirements/dev.in
 #
+appnope==0.1.3
+    # via
+    #   ipykernel
+    #   ipython
 argon2-cffi==21.3.0
     # via notebook
 argon2-cffi-bindings==21.2.0
@@ -17,7 +21,7 @@ backcall==0.2.0
 beautifulsoup4==4.11.1
     # via nbconvert
 black==22.10.0
-    # via -r dev.in
+    # via -r requirements/dev.in
 bleach==5.0.1
     # via nbconvert
 build==0.8.0
@@ -41,7 +45,11 @@ executing==1.0.0
 fastjsonschema==2.16.2
     # via nbformat
 flake8==5.0.4
-    # via -r dev.in
+    # via -r requirements/dev.in
+importlib-metadata==5.0.0
+    # via nbconvert
+importlib-resources==5.10.0
+    # via jsonschema
 ipykernel==6.17.0
     # via
     #   ipywidgets
@@ -51,7 +59,7 @@ ipykernel==6.17.0
     #   qtconsole
 ipython==8.6.0
     # via
-    #   -r dev.in
+    #   -r requirements/dev.in
     #   ipykernel
     #   ipywidgets
     #   jupyter-console
@@ -70,7 +78,7 @@ jinja2==3.1.2
 jsonschema==4.16.0
     # via nbformat
 jupyter==1.0.0
-    # via -r dev.in
+    # via -r requirements/dev.in
 jupyter-client==7.3.5
     # via
     #   ipykernel
@@ -106,7 +114,7 @@ mccabe==0.7.0
 mistune==2.0.4
     # via nbconvert
 mypy==0.982
-    # via -r dev.in
+    # via -r requirements/dev.in
 mypy-extensions==0.4.3
     # via
     #   black
@@ -149,7 +157,9 @@ pexpect==4.8.0
 pickleshare==0.7.5
     # via ipython
 pip-tools==6.9.0
-    # via -r dev.in
+    # via -r requirements/dev.in
+pkgutil-resolve-name==1.3.10
+    # via jsonschema
 platformdirs==2.5.2
     # via black
 prometheus-client==0.14.1
@@ -235,7 +245,9 @@ traitlets==5.4.0
     #   notebook
     #   qtconsole
 typing-extensions==4.3.0
-    # via mypy
+    # via
+    #   black
+    #   mypy
 wcwidth==0.2.5
     # via prompt-toolkit
 webencodings==0.5.1
@@ -246,6 +258,10 @@ wheel==0.37.1
     # via pip-tools
 widgetsnbextension==4.0.3
     # via ipywidgets
+zipp==3.10.0
+    # via
+    #   importlib-metadata
+    #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile requirements/test.in
 #
+appnope==0.1.3
+    # via
+    #   ipykernel
+    #   ipython
 asttokens==2.0.8
     # via
     #   nbdev
@@ -15,10 +19,10 @@ attrs==22.1.0
 backcall==0.2.0
     # via ipython
 black==22.10.0
-    # via -r test.in
+    # via -r requirements/test.in
 click==8.1.3
     # via
-    #   -r test.in
+    #   -r requirements/test.in
     #   black
 coverage[toml]==6.4.4
     # via pytest-cov
@@ -38,13 +42,13 @@ fastcore==1.5.27
     #   ghapi
     #   nbdev
 flake8==5.0.4
-    # via -r test.in
+    # via -r requirements/test.in
 ghapi==1.0.3
     # via nbdev
 iniconfig==1.1.1
     # via pytest
 ipykernel==6.17.0
-    # via -r test.in
+    # via -r requirements/test.in
 ipython==8.6.0
     # via
     #   execnb
@@ -62,13 +66,13 @@ matplotlib-inline==0.1.6
 mccabe==0.7.0
     # via flake8
 mypy==0.982
-    # via -r test.in
+    # via -r requirements/test.in
 mypy-extensions==0.4.3
     # via
     #   black
     #   mypy
 nbdev==2.3.7
-    # via -r test.in
+    # via -r requirements/test.in
 nest-asyncio==1.5.6
     # via
     #   ipykernel
@@ -112,7 +116,7 @@ pyparsing==3.0.9
 pytest==7.1.3
     # via pytest-cov
 pytest-cov==4.0.0
-    # via -r test.in
+    # via -r requirements/test.in
 python-dateutil==2.8.2
     # via jupyter-client
 pyyaml==6.0
@@ -146,7 +150,9 @@ traitlets==5.4.0
     #   jupyter-core
     #   matplotlib-inline
 typing-extensions==4.3.0
-    # via mypy
+    # via
+    #   black
+    #   mypy
 watchdog==2.1.9
     # via nbdev
 wcwidth==0.2.5


### PR DESCRIPTION
This fixes an issue where

    make generate-api

would throw an error due to `types-ujson` not being installed.