### PR TITLE
refactor: checking sed version

### DIFF
--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -116,6 +116,12 @@ for i in "${!FILES_TO_CHECK[@]}"; do
     else
         # Replace semver in VERSIONFILE with semver obtained from SOURCE_FILE
         TMPFILE=$(mktemp /tmp/new_version.XXXXXX)
+	# Check sed version, exit if version < 4.3
+        CURRENT_VERSION=$(sed --version | head -n1 | cut -d" " -f4)
+        REQUIRED_VERSION="4.3"
+        if [ "$(printf '%s\n' "$REQUIRED_VERSION" "$CURRENT_VERSION" | sort -V | head -n1)" != "$REQUIRED_VERSION" ]; then
+            echo "sed version must be >= ${REQUIRED_VERSION}" && exit 1
+        fi
         sed -E -r "s/$RE_SEMVER/$UPDATED_VERSION/" "$FILE_TO_CHANGE" > "$TMPFILE"
         if [ $CHECK == 1 ];
         then

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -117,7 +117,11 @@ for i in "${!FILES_TO_CHECK[@]}"; do
         # Replace semver in VERSIONFILE with semver obtained from SOURCE_FILE
         TMPFILE=$(mktemp /tmp/new_version.XXXXXX)
 	# Check sed version, exit if version < 4.3
-        CURRENT_VERSION=$(sed --version | head -n1 | cut -d" " -f4)
+	if ! /usr/bin/sed --version > /dev/null 2>&1; then
+            CURRENT_VERSION=1.archaic
+        else
+            CURRENT_VERSION=$(sed --version | head -n1 | cut -d" " -f4)
+        fi
         REQUIRED_VERSION="4.3"
         if [ "$(printf '%s\n' "$REQUIRED_VERSION" "$CURRENT_VERSION" | sort -V | head -n1)" != "$REQUIRED_VERSION" ]; then
             echo "sed version must be >= ${REQUIRED_VERSION}" && exit 1

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -117,7 +117,7 @@ for i in "${!FILES_TO_CHECK[@]}"; do
         # Replace semver in VERSIONFILE with semver obtained from SOURCE_FILE
         TMPFILE=$(mktemp /tmp/new_version.XXXXXX)
 	# Check sed version, exit if version < 4.3
-	if ! /usr/bin/sed --version > /dev/null 2>&1; then
+	if ! sed --version > /dev/null 2>&1; then
             CURRENT_VERSION=1.archaic
         else
             CURRENT_VERSION=$(sed --version | head -n1 | cut -d" " -f4)


### PR DESCRIPTION
This PR address [this issue](https://github.com/Unstructured-IO/community/issues/41) which asks for a graceful exit in cases where the version of `sed` is less than 4.3. I have made this version check in my commit and used `exit 1` if the check fails. Do let me know if any changes are required. Specifically, I am unsure about the position of the check inside the code and if the exit needs to be more comprehensive (like killing child processes if they exist, etc.).