### PR TITLE
chore: Update how pipeline-notebook fetches filing

### DIFF
--- a/pipeline-notebooks/pipeline-section.ipynb
+++ b/pipeline-notebooks/pipeline-section.ipynb
@@ -196,15 +196,24 @@
    "outputs": [],
    "source": [
     "from prepline_sec_filings.fetch import (\n",
-    "    get_form_by_ticker, open_form_by_ticker\n",
+    "    get_form_by_ticker, open_form_by_ticker, get_filing\n",
     ")\n",
     "\n",
-    "text = get_form_by_ticker(\n",
-    "    'rgld', \n",
-    "    '10-K', \n",
-    "    company='Unstructured Technologies', \n",
-    "    email='support@unstructured.io'\n",
-    ")"
+    "# Fetch the 2021 10-K instead of the most recent one\n",
+    "rgld_cik = 85535\n",
+    "accession_number = \"000155837021011343\"\n",
+    "text = get_filing(rgld_cik,\n",
+    "                  accession_number,\n",
+    "                  company='Unstructured Technologies', \n",
+    "                  email='support@unstructured.io')\n",
+    "\n",
+    "# Alternatively, use the following to fetch the most recent filing:\n",
+    "# text = get_form_by_ticker(\n",
+    "#    'rgld', \n",
+    "#    '10-K', \n",
+    "#    company='Unstructured Technologies', \n",
+    "#    email='support@unstructured.io'\n",
+    "#)\n"
    ]
   },
   {


### PR DESCRIPTION
The filing being fetched in one notebook is no longer the most recent annual report,
so the prior annual report must be fetched with a different function call.