### PR TITLE
chore: update notebook with latest filing drift

### DIFF
--- a/exploration-notebooks/exploration-10k-risks.ipynb
+++ b/exploration-notebooks/exploration-10k-risks.ipynb
@@ -44,7 +44,7 @@
    "source": [
     "### Westamerica Bancorp Filing <a id=\"wabc\"></a>\n",
     "\n",
-    "This section pulls in the latest WABC 10-K filing from the SEC site, which is available [here](https://www.sec.gov/Archives/edgar/data/311094/000117184322001403/wabc20211231_10k.htm). The goal is to identify the [risk factors](https://www.sec.gov/Archives/edgar/data/311094/000117184321001344/wabc20201231_10k.htm#i1a) section."
+    "This section pulls in the 2022 WABC 10-K filing from the SEC site, which is available [here](https://www.sec.gov/Archives/edgar/data/311094/000117184322001403/wabc20211231_10k.htm). The goal is to identify the [risk factors](https://www.sec.gov/Archives/edgar/data/311094/000117184321001344/wabc20201231_10k.htm#i1a) section."
    ]
   },
   {
@@ -54,10 +54,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "text = get_form_by_ticker(ticker=\"WABC\",\n",
-    "                          form_type=\"10-K\",\n",
-    "                          company=\"Unstructured Technologies\",\n",
-    "                          email=\"support@unstructured.io\")"
+    "# This would get the most recent 10-k filing\n",
+    "#text = get_form_by_ticker(ticker=\"WABC\",\n",
+    "#                          form_type=\"10-K\",\n",
+    "#                          company=\"Unstructured Technologies\",\n",
+    "#                          email=\"support@unstructured.io\")\n",
+    "\n",
+    "# This gets the 2022 Filing\n",
+    "text = get_filing(\"311094\",\n",
+    "                  \"000117184322001403\", \n",
+    "                  \"Unstructured Technologies\",\n",
+    "                  \"support@unstructured.io\")\n"
    ]
   },
   {

--- a/exploration-notebooks/exploration-10q-amended.ipynb
+++ b/exploration-notebooks/exploration-10q-amended.ipynb
@@ -103,13 +103,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "adra-10-QA-0001823584-000141057822002776.xbrl\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "adra-10-QA-0001823584-000141057822002776.xbrl\n",
       "adra-10-Q-0001823584-000141057822002300.xbrl\n"
      ]
     }
@@ -141,13 +135,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " ===================================================== 10-Q/A\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      " ===================================================== 10-Q/A\n",
       "Table of Contents\n",
       "\n",
       "UNITED STATES\n",
@@ -163,13 +151,7 @@
       "(MARK ONE)\n",
       "\n",
       "☒ QUARTERLY REPORT PURSUANT TO SECTION 13 OR 15(d) OF THE SECURIT\n",
-      " ===================================================== 10-Q\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      " ===================================================== 10-Q\n",
       "Table of Contents\n",
       "\n",
       "UNITED STATES\n",
@@ -222,33 +204,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "LEGAL_PROCEEDINGS\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "LEGAL_PROCEEDINGS\n",
       "    ....\n",
       "-----\n",
-      "RISK_FACTORS\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "RISK_FACTORS\n",
       "As of the date of this Quarterly Report there have been no changes to the risk factors disclosed in our Annual Report on Form 10-K filed with the SEC on March 28, 2022.\n",
       "    ....\n",
       "As of the date of this Quarterly Report there have been no changes to the risk factors disclosed in our Annual Report on Form 10-K filed with the SEC on March 28, 2022.\n",
       "-----\n",
-      "MANAGEMENT_DISCUSSION\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "MANAGEMENT_DISCUSSION\n",
       "References in this report (the “Quarterly Report”) to “we,” “us” or the “Company” refer to Adara Acquisition Corp. References to our “management” or our “management team” refer to our officers and directors, and references to the “Sponsor” refer to Adara Sponsor LLC. The following discussion and analysis of the Company’s financial condition and results of operations should be read in conjunction with the financial statements and the notes thereto contained elsewhere in this Quarterly Report. Certain information contained in the discussion and analysis set forth below includes forward-looking statements that involve risks and uncertainties.\n",
       "This Quarterly Report includes “forward-looking statements” within the meaning of Section 27A of the Securities Act of 1933, as amended and Section 21E of the Exchange Act of 1934, as amended (the “Exchange Act”) that are not historical facts and involve risks and uncertainties that could cause actual results to differ materially from those expected and projected. All statements, other than statements of historical fact included in this Quarterly Report including, without limitation, statements in this “Management’s Discussion and Analysis of Financial Condition and Results of Operations” regarding the completion of the Proposed Business Combination (as defined below), the Company’s financial position, business strategy and the plans and objectives of management for future operations, are forward-looking statements. Words such as “expect,” “believe,” “anticipate,” “intend,” “estimate,” “seek” and variations and similar words and expressions are intended to identify such forward-looking statements. Such forward-looking statements relate to future events or future performance, but reflect management’s current beliefs, based on information currently available. A number of factors could cause actual events, performance or results to differ materially from the events, performance and results discussed in the forward-looking statements, including that the conditions of the Proposed Business Combination are not satisfied. For information identifying important factors that could cause actual results to differ materially from those anticipated in the forward-looking statements, please refer to the Risk Factors section of the Company’s Annual Report on Form 10-K filed with the U.S. Securities and Exchange Commission (the “SEC”). The Company’s securities filings can be accessed on the EDGAR section of the SEC’s website at www.sec.gov. Except as expressly required by applicable securities law, the Company disclaims any intention or obligation to update or revise any forward-looking statements whether as a result of new information, future events or otherwise.\n",
       "    ....\n",
@@ -272,33 +236,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "LEGAL_PROCEEDINGS\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "LEGAL_PROCEEDINGS\n",
       "    ....\n",
       "-----\n",
-      "RISK_FACTORS\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "RISK_FACTORS\n",
       "As of the date of this Quarterly Report there have been no changes to the risk factors disclosed in our Annual Report on Form 10-K filed with the SEC on March 28, 2022.\n",
       "    ....\n",
       "As of the date of this Quarterly Report there have been no changes to the risk factors disclosed in our Annual Report on Form 10-K filed with the SEC on March 28, 2022.\n",
       "-----\n",
-      "MANAGEMENT_DISCUSSION\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "MANAGEMENT_DISCUSSION\n",
       "References in this report (the “Quarterly Report”) to “we,” “us” or the “Company” refer to Adara Acquisition Corp. References to our “management” or our “management team” refer to our officers and directors, and references to the “Sponsor” refer to Adara Sponsor LLC. The following discussion and analysis of the Company’s financial condition and results of operations should be read in conjunction with the financial statements and the notes thereto contained elsewhere in this Quarterly Report. Certain information contained in the discussion and analysis set forth below includes forward-looking statements that involve risks and uncertainties.\n",
       "This Quarterly Report includes “forward-looking statements” within the meaning of Section 27A of the Securities Act of 1933, as amended and Section 21E of the Exchange Act of 1934, as amended (the “Exchange Act”) that are not historical facts and involve risks and uncertainties that could cause actual results to differ materially from those expected and projected. All statements, other than statements of historical fact included in this Quarterly Report including, without limitation, statements in this “Management’s Discussion and Analysis of Financial Condition and Results of Operations” regarding the completion of the Proposed Business Combination (as defined below), the Company’s financial position, business strategy and the plans and objectives of management for future operations, are forward-looking statements. Words such as “expect,” “believe,” “anticipate,” “intend,” “estimate,” “seek” and variations and similar words and expressions are intended to identify such forward-looking statements. Such forward-looking statements relate to future events or future performance, but reflect management’s current beliefs, based on information currently available. A number of factors could cause actual events, performance or results to differ materially from the events, performance and results discussed in the forward-looking statements, including that the conditions of the Proposed Business Combination are not satisfied. For information identifying important factors that could cause actual results to differ materially from those anticipated in the forward-looking statements, please refer to the Risk Factors section of the Company’s Annual Report on Form 10-K filed with the U.S. Securities and Exchange Commission (the “SEC”). The Company’s securities filings can be accessed on the EDGAR section of the SEC’s website at www.sec.gov. Except as expressly required by applicable securities law, the Company disclaims any intention or obligation to update or revise any forward-looking statements whether as a result of new information, future events or otherwise.\n",
       "    ....\n",

--- a/scripts/check-and-format-notebooks.py
+++ b/scripts/check-and-format-notebooks.py
@@ -91,6 +91,7 @@ if __name__ == "__main__":
     nonmatching_nbs = []
     fns = notebooks if notebooks else nb_paths(root_path)
     for fn in fns:
+        print(f"{'checking' if check else 'processing'} {fn}")
         nb = read_notebook(fn)
         modified_nb = deepcopy(nb)
         process_nb(modified_nb, root_path)

--- a/scripts/check-and-format-notebooks.py
+++ b/scripts/check-and-format-notebooks.py
@@ -17,10 +17,45 @@ from unstructured_api_tools.pipelines.convert import read_notebook
 def process_nb(nb: nbformat.NotebookNode, working_dir: Union[str, Path]) -> nbformat.NotebookNode:
     """Execute cells in nb using working_dir as the working directory for imports, modifying the
     notebook in place (in memory)."""
+    # Clear existing outputs before executing the notebook
+    for cell in nb.cells:
+        if cell.cell_type == "code":
+            cell.outputs = []
     ep = ExecutePreprocessor(timeout=600)
     ep.preprocess(nb, {"metadata": {"path": working_dir}})
+    # Merge adjacent text outputs after executing the notebook
+    for cell in nb.cells:
+        merge_adjacent_text_outputs(cell)
     return nb
 
+def merge_adjacent_text_outputs(cell: nbformat.NotebookNode) -> nbformat.NotebookNode:
+    """Merges adjacent text stream outputs to avoid non-deterministic splits in output."""
+    if cell.cell_type != "code":
+        return cell
+
+    new_outputs = []
+    current_output = None
+
+    for output in cell.outputs:
+        if output.output_type == "stream":
+            if current_output is None:
+                current_output = output
+            elif current_output.name == output.name:
+                current_output.text += output.text
+            else:
+                new_outputs.append(current_output)
+                current_output = output
+        else:
+            if current_output is not None:
+                new_outputs.append(current_output)
+                current_output = None
+            new_outputs.append(output)
+
+    if current_output is not None:
+        new_outputs.append(current_output)
+
+    cell.outputs = new_outputs
+    return cell
 
 def nb_paths(root_path: Union[str, Path]) -> List[Path]:
     """Fetches all .ipynb filenames that belong to subdirectories of root_path (1 level deep) with


### PR DESCRIPTION
Bonuses!

* print notebooks as they checked/processed by scripts/check-and-format-notebooks.py , which makes debuging a touch easier when there is a failure. Also just nice to see what it is going on if there are no changes -- it takes awhile to process 5 notebooks.
* Merge output `stream` cells to avoid non-deterministic diff errors like (which are actually equivalent outputs):

```
The following diff shows the modifications made to exploration-notebooks/exploration-10q-amended.ipynb
checking exploration-notebooks/exploration-10k-risks.ipynb
--- 
+++ 
@@ -70,7 +70,12 @@
         {
           "name": "stdout",
           "output_type": "stream",
-          "text": " ===================================================== 10-Q/A\n"
+          "text": " ===================================================== 10-Q/A"
+        },
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": "\n"
         },
         {
           "name": "stdout",
```